### PR TITLE
Remove userMeta dependency and hardcode URLs in next.config.ts

### DIFF
--- a/apps/portfolio/next.config.ts
+++ b/apps/portfolio/next.config.ts
@@ -1,4 +1,3 @@
-import { userMeta } from '@repo/shared';
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
@@ -14,8 +13,8 @@ const nextConfig: NextConfig = {
         ]
     },
     publicRuntimeConfig: {
-        siteURL: userMeta.siteURL,
-        sitemapURL: `${userMeta.siteURL}/sitemap.xml`
+        siteURL: 'https://kzaman.me',
+        sitemapURL: `https://kzaman.me/sitemap.xml`
     }
 };
 


### PR DESCRIPTION
Eliminate the dependency on userMeta by hardcoding the siteURL and sitemapURL directly in the configuration file.